### PR TITLE
Chop mapping with coefficients smaller than threshold

### DIFF
--- a/groupedFermionicOperator.py
+++ b/groupedFermionicOperator.py
@@ -140,6 +140,9 @@ class groupedFermionicOperator:
         """
         
         mapping = self.mapping
+        for i in mapping:
+            mapping[i] = mapping[i].chop(threshold=self.THRESHOLD)
+
         qubitOp = WeightedPauliOperator(paulis=[])
         for k, w in self.grouped_op.items():
             if np.ndim(k) == 1: ## one-e-term


### PR DESCRIPTION
Chop the `WeightedPauliOperator`s in `mapping` so that the code will be more efficient before transforming into qubit operators in `to_paulis`